### PR TITLE
Fix automerge for longer CI

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,9 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@8813d079052adec7a6ea5d0855c0543fcd78f701"
+        uses: "pascalgn/automerge-action@v0.7.5"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_COMMIT_MESSAGE: "pull-request-description"
           MERGE_LABELS: "!wip,ready-to-squash-and-merge"
           MERGE_METHOD: "squash"
+          # CI takes several minutes, so only retry the merge
+          # every 2 MIN = 120 SEC = 120000 MS
+          MERGE_RETRY_SLEEP: 120000


### PR DESCRIPTION
The CI takes ~10 minutes, so retry the merge every 2 minutes using the default 6 times.