### PR TITLE
Update Docker image to Rust 1.42

### DIFF
--- a/app/pocket_cleaner/Dockerfile
+++ b/app/pocket_cleaner/Dockerfile
@@ -1,6 +1,6 @@
 # You can override this `--build-arg BASE_IMAGE=...` to use different
 # version of Rust or OpenSSL.
-ARG BASE_IMAGE=rust:1.41.1-buster
+ARG BASE_IMAGE=rust:1.42.0-buster
 
 # Our first FROM statement declares the build environment.
 FROM ${BASE_IMAGE} AS builder


### PR DESCRIPTION
* [Official announcement](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html)
* Major features:
   * Useful line numbers in panic messages for`Option` and `Result`
   * Better subslice patterns