### PR TITLE
Remove archived and deleted items

### DIFF
--- a/app/pocket_cleaner/src/bin/pc_console.rs
+++ b/app/pocket_cleaner/src/bin/pc_console.rs
@@ -132,6 +132,10 @@ enum SavedItemDBSubcommand {
         #[structopt(long)]
         sort: Option<SavedItemSortBy>,
     },
+    Delete {
+        #[structopt(long)]
+        user_id: i32,
+    },
 }
 
 async fn run_trends_subcommand() -> Result<()> {
@@ -277,6 +281,9 @@ fn run_saved_item_db_subcommand(
                         .unwrap_or_else(|| "none".into())
                 );
             }
+        }
+        SavedItemDBSubcommand::Delete { user_id } => {
+            saved_item_store.delete_all(*user_id)?;
         }
     }
     Ok(())

--- a/app/pocket_cleaner/src/lib.rs
+++ b/app/pocket_cleaner/src/lib.rs
@@ -6,7 +6,10 @@ extern crate diesel_migrations;
 use crate::{
     data_store::{SavedItemStore, UpsertSavedItem, UserStore},
     error::Result,
-    pocket::{PocketPage, PocketRetrieveItemState, PocketRetrieveQuery, UserPocketManager},
+    pocket::{
+        PocketItemStatus, PocketPage, PocketRetrieveItemState, PocketRetrieveQuery,
+        UserPocketManager,
+    },
 };
 
 pub mod config;
@@ -82,20 +85,29 @@ impl<'a> SavedItemMediator<'a> {
                     ..Default::default()
                 })
                 .await?;
-            let store_items: Vec<_> = items
-                .into_iter()
-                .map(|item| UpsertSavedItem {
-                    user_id,
-                    pocket_id: item.id(),
-                    title: item.title(),
-                    excerpt: item.excerpt(),
-                    url: item.url(),
-                    time_added: item.time_added(),
-                })
-                .collect();
-            self.saved_item_store.upsert_items(&store_items)?;
-            log::debug!("Synced {} items to DB (page {})", store_items.len(), page);
-            let num_stored_items = store_items.len() as u32;
+
+            for item in &items {
+                match item.status() {
+                    PocketItemStatus::Unread => {
+                        // Create or update the item
+                        self.saved_item_store.upsert_item(&UpsertSavedItem {
+                            user_id,
+                            pocket_id: item.id(),
+                            title: item.title(),
+                            excerpt: item.excerpt(),
+                            url: item.url(),
+                            time_added: item.time_added(),
+                        })?;
+                    }
+                    PocketItemStatus::Archived | PocketItemStatus::Deleted => {
+                        // Delete the item if it exists
+                        self.saved_item_store.delete_item(user_id, &item.id())?;
+                    }
+                }
+            }
+
+            log::debug!("Synced {} items to DB (page {})", items.len(), page);
+            let num_stored_items = items.len() as u32;
             offset += num_stored_items;
             if num_stored_items < ITEMS_PER_PAGE {
                 break since;

--- a/app/pocket_cleaner/src/pocket.rs
+++ b/app/pocket_cleaner/src/pocket.rs
@@ -34,10 +34,28 @@ impl PocketManager {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum PocketItemStatus {
+    Unread,
+    Archived,
+    Deleted,
+}
+
+impl From<RemotePocketItemStatus> for PocketItemStatus {
+    fn from(status: RemotePocketItemStatus) -> PocketItemStatus {
+        match status {
+            RemotePocketItemStatus::Unread => Self::Unread,
+            RemotePocketItemStatus::Archived => Self::Archived,
+            RemotePocketItemStatus::Deleted => Self::Deleted,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct PocketItem {
     id: String,
     title: String,
+    status: PocketItemStatus,
     excerpt: String,
     url: String,
     time_added: NaiveDateTime,
@@ -92,6 +110,9 @@ impl PocketItem {
     pub fn title(&self) -> String {
         self.title.clone()
     }
+    pub fn status(&self) -> PocketItemStatus {
+        self.status
+    }
     pub fn excerpt(&self) -> String {
         self.excerpt.clone()
     }
@@ -118,6 +139,7 @@ impl TryFrom<RemotePocketItem> for PocketItem {
         Ok(Self {
             id: remote.item_id.0,
             title,
+            status: remote.status.into(),
             excerpt: remote.excerpt,
             url: remote.given_url,
             time_added: NaiveDateTime::from_timestamp(time_added, 0 /*nsecs*/),


### PR DESCRIPTION
When an item is now archived or deleted, this change causes `sync` to remove the item from the database.

* Add item status to `RemotePocketItem`
* Change `sync` to request all items (unread and archived), but continue to create/update unread items and now delete read/deleted items
* Add `db saved-item delete --user-id <id>` API to delete all saved items for the user - this will be used to migrate the db