### PR TITLE
Add Continuous Deployments to Heroku

### DIFF
--- a/.github/workflows/pocket_cleaner.ci.yml
+++ b/.github/workflows/pocket_cleaner.ci.yml
@@ -85,7 +85,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [check, test, fmt, clippy]
-    if: github.event_name == 'push' and github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v1
       - name: Login to Heroku Container registry


### PR DESCRIPTION
When `check`, `test`, `fmt`, and `clippy` pass on `master`, then the new `deploy` job will run which deploy to Heroku.

Added [Deployment wiki page](https://github.com/rgardner/memory-jogger/wiki/Deployment).