### PR TITLE
Fix automerge by increasing timeout and retries

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,5 +29,5 @@ jobs:
           MERGE_COMMIT_MESSAGE: "pull-request-description"
           MERGE_LABELS: "automerge,!wip"
           MERGE_METHOD: "squash"
-          MERGE_RETRIES: 10
-          MERGE_RETRY_SLEEP: 30000
+          MERGE_RETRIES: 15
+          MERGE_RETRY_SLEEP: 60000


### PR DESCRIPTION
Docker takes about 10 minutes currently, so 15 retries of 1min each
gives breathing room.
