### PR TITLE
Upgrade to latest for all deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "assert_cmd"
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -195,12 +195,13 @@ dependencies = [
 [[package]]
 name = "diesel"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel.git?rev=fa826f0c97e1f47eef34f37cb5b60056855a2b9a#fa826f0c97e1f47eef34f37cb5b60056855a2b9a"
+source = "git+https://github.com/diesel-rs/diesel.git?rev=7e676025dd11fa5b50399a2dcf9887b37280abe6#7e676025dd11fa5b50399a2dcf9887b37280abe6"
 dependencies = [
  "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "itoa",
  "libsqlite3-sys",
  "pq-sys",
 ]
@@ -208,7 +209,7 @@ dependencies = [
 [[package]]
 name = "diesel_derives"
 version = "2.0.0"
-source = "git+https://github.com/diesel-rs/diesel.git?rev=fa826f0c97e1f47eef34f37cb5b60056855a2b9a#fa826f0c97e1f47eef34f37cb5b60056855a2b9a"
+source = "git+https://github.com/diesel-rs/diesel.git?rev=7e676025dd11fa5b50399a2dcf9887b37280abe6#7e676025dd11fa5b50399a2dcf9887b37280abe6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -217,9 +218,10 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "1.4.0"
-source = "git+https://github.com/diesel-rs/diesel.git?rev=fa826f0c97e1f47eef34f37cb5b60056855a2b9a#fa826f0c97e1f47eef34f37cb5b60056855a2b9a"
+version = "2.0.0"
+source = "git+https://github.com/diesel-rs/diesel.git?rev=7e676025dd11fa5b50399a2dcf9887b37280abe6#7e676025dd11fa5b50399a2dcf9887b37280abe6"
 dependencies = [
+ "diesel",
  "migrations_internals",
  "migrations_macros",
 ]
@@ -247,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -260,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab01c2450bed354679e78bedbff1484e02910ef1be96755086a36cadd1247efa"
+checksum = "44bb3f795fe1b9d34f089c7fab034c2b757998d65361d95ef008045b57665262"
 dependencies = [
  "log",
  "once_cell",
@@ -650,16 +652,17 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "1.4.1"
-source = "git+https://github.com/diesel-rs/diesel.git?rev=fa826f0c97e1f47eef34f37cb5b60056855a2b9a#fa826f0c97e1f47eef34f37cb5b60056855a2b9a"
+version = "2.0.0"
+source = "git+https://github.com/diesel-rs/diesel.git?rev=7e676025dd11fa5b50399a2dcf9887b37280abe6#7e676025dd11fa5b50399a2dcf9887b37280abe6"
 dependencies = [
- "diesel",
+ "serde",
+ "toml",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "1.4.2"
-source = "git+https://github.com/diesel-rs/diesel.git?rev=fa826f0c97e1f47eef34f37cb5b60056855a2b9a#fa826f0c97e1f47eef34f37cb5b60056855a2b9a"
+version = "2.0.0"
+source = "git+https://github.com/diesel-rs/diesel.git?rev=7e676025dd11fa5b50399a2dcf9887b37280abe6#7e676025dd11fa5b50399a2dcf9887b37280abe6"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -697,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1033,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64",
  "bytes 1.0.1",
@@ -1108,9 +1111,9 @@ checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "security-framework"
-version = "0.4.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1121,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1146,18 +1149,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1166,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1315,9 +1318,9 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -1362,6 +1365,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1450,9 +1462,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow = "1.0.40"
 chrono = "0.4.19"
 # TODO: Set diesel and diesel_migrations to version once SQLite upsert support has been released
-diesel = { git = "https://github.com/diesel-rs/diesel.git", rev = "fa826f0c97e1f47eef34f37cb5b60056855a2b9a", features = ["chrono"] }
-diesel_migrations = { git = "https://github.com/diesel-rs/diesel.git", rev = "fa826f0c97e1f47eef34f37cb5b60056855a2b9a" }
-env_logger = "0.8.2"
+diesel = { git = "https://github.com/diesel-rs/diesel.git", rev = "7e676025dd11fa5b50399a2dcf9887b37280abe6", features = ["chrono"] }
+diesel_migrations = { git = "https://github.com/diesel-rs/diesel.git", rev = "7e676025dd11fa5b50399a2dcf9887b37280abe6" }
+env_logger = "0.8.3"
 log = "0.4.14"
-reqwest = { version = "0.11.0", features = ["json"] }
-serde = { version = "1.0.123", features = ["derive"] }
-serde_json = "1.0.62"
+reqwest = { version = "0.11.2", features = ["json"] }
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = "1.0.64"
 structopt = "0.3.21"
-tokio = { version = "1.2.0", features = ["macros", "rt-multi-thread"] }
-url = "2.2.0"
+tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread"] }
+url = "2.2.1"
 
 [features]
 default = ["postgres", "sqlite"]
@@ -36,6 +36,6 @@ large_tests = []
 assert_cmd = "1.0.3"
 assert_fs = "1.0.1"
 cfg-if = "1.0.0"
-escargot = "0.5.1"
+escargot = "0.5.2"
 lazy_static = "1.4.0"
 predicates = "1.0.7"

--- a/src/data_store/sqlite.rs
+++ b/src/data_store/sqlite.rs
@@ -2,8 +2,9 @@
 
 use std::{cmp::Ordering, rc::Rc};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use diesel::prelude::*;
+use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 
 use super::{
     GetSavedItemsQuery, SavedItem, SavedItemSort, SavedItemStore, UpsertSavedItem, User, UserStore,
@@ -14,7 +15,8 @@ mod models;
 #[rustfmt::skip]
 mod schema;
 
-diesel_migrations::embed_migrations!("migrations/sqlite");
+pub const MIGRATIONS: EmbeddedMigrations =
+    diesel_migrations::embed_migrations!("migrations/sqlite");
 
 impl From<models::User> for User {
     fn from(model: models::User) -> Self {
@@ -367,6 +369,7 @@ pub fn initialize_db(database_url: &str) -> Result<SqliteConnection> {
     let conn = SqliteConnection::establish(&database_url)
         .context("Failed to connect to SQLite database")?;
     conn.execute("PRAGMA foreign_keys = ON")?;
-    embedded_migrations::run_with_output(&conn, &mut std::io::stdout())?;
+    conn.run_pending_migrations(MIGRATIONS)
+        .map_err(|e| anyhow!(e))?;
     Ok(conn)
 }


### PR DESCRIPTION
Fixes a breaking changes in `diesel_migrations` for running pending migrations.